### PR TITLE
feat: add 커뮤니티 카테고리 목록 page, size 1에 20으로 맞춤

### DIFF
--- a/backend/src/main/java/com/teamlms/backend/domain/community/api/FaqCategoryController.java
+++ b/backend/src/main/java/com/teamlms/backend/domain/community/api/FaqCategoryController.java
@@ -8,16 +8,17 @@ import com.teamlms.backend.global.api.PageMeta;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
+import java.util.List;
 
 @RestController
-@RequestMapping //("/api/v1/community/faq/categories") // 정책서 경로: /faq/categories
+@RequestMapping 
 @RequiredArgsConstructor
 public class FaqCategoryController {
 
@@ -26,15 +27,31 @@ public class FaqCategoryController {
     // 1. FAQ 카테고리 목록 조회 - 전부가능
     // =================================================================
     @GetMapping({"/api/v1/student/community/faq/categories",
-                 "/api/v1/professor/community/faq/categories",
-                 "/api/v1/admin/community/faq/categories"
-    })
+                "/api/v1/admin/community/faq/categories",
+                "/api/v1/professor/community/faq/categories"})
     @PreAuthorize("hasAuthority('FAQ_READ')")
-    public ApiResponse<?> getList(
-            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
+    public ApiResponse<List<ExternalCategoryResponse>> getStudentFaqCategories(
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "20") int size,
             @RequestParam(required = false) String keyword) {
-        Page<ExternalCategoryResponse> result = service.getList(pageable, keyword);
-        return ApiResponse.of(result.getContent(), PageMeta.from(result));
+        return getFaqCategoryListInternal(page, size, keyword);
+    }
+    private ApiResponse<List<ExternalCategoryResponse>> getFaqCategoryListInternal(int page, int size, String keyword) {
+        int safePage = Math.max(page, 1);
+        int safeSize = Math.min(Math.max(size, 1), 100);
+
+        Pageable pageable = PageRequest.of(
+                safePage - 1,
+                safeSize,
+                Sort.by(Sort.Direction.DESC, "createdAt")
+        );
+   
+        Page<ExternalCategoryResponse> pageResult = service.getList(pageable, keyword);
+        
+        return ApiResponse.of(
+                pageResult.getContent(), 
+                PageMeta.from(pageResult)
+        );
     }
 
     // =================================================================

--- a/backend/src/main/java/com/teamlms/backend/domain/community/api/QnaCategoryController.java
+++ b/backend/src/main/java/com/teamlms/backend/domain/community/api/QnaCategoryController.java
@@ -8,15 +8,16 @@ import com.teamlms.backend.global.api.PageMeta;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import java.util.Map;
+import java.util.List;
 
 @RestController
-@RequestMapping // ("/api/v1/community/qna/categories")
+@RequestMapping 
 @RequiredArgsConstructor
 public class QnaCategoryController {
 
@@ -25,15 +26,33 @@ public class QnaCategoryController {
     // 1. Q&A 카테고리 목록 조회 - 전부가능
     // =================================================================
     @GetMapping({"/api/v1/student/community/qna/categories",
-                 "/api/v1/professor/community/qna/categories",
-                 "/api/v1/admin/community/qna/categories"
-    })
+                 "/api/v1/admin/community/qna/categories",
+                 "/api/v1/professor/community/qna/categories"})
     @PreAuthorize("hasAuthority('QNA_READ')")
-    public ApiResponse<?> getList(
-            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
+    public ApiResponse<List<ExternalCategoryResponse>> getQnaCategories(
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "20") int size,
             @RequestParam(required = false) String keyword) {
-        Page<ExternalCategoryResponse> result = service.getList(pageable, keyword);
-        return ApiResponse.of(result.getContent(), PageMeta.from(result));
+        return getQnaCategoryListInternal(page, size, keyword);
+    }
+
+   
+    private ApiResponse<List<ExternalCategoryResponse>> getQnaCategoryListInternal(int page, int size, String keyword) {
+        int safePage = Math.max(page, 1);
+        int safeSize = Math.min(Math.max(size, 1), 100);
+
+        Pageable pageable = PageRequest.of(
+                safePage - 1,
+                safeSize,
+                Sort.by(Sort.Direction.DESC, "createdAt")
+        );
+
+        Page<ExternalCategoryResponse> pageResult = service.getList(pageable, keyword);
+        
+        return ApiResponse.of(
+                pageResult.getContent(), 
+                PageMeta.from(pageResult)
+        );
     }
     
     // =================================================================


### PR DESCRIPTION
## ✅ Summary
- 커뮤니티 카테고리 목록 조회에서 page = 1, size = 20 으로 맞추는 작업 

## 📌 Scope
- [o] Backend
- [ ] Frontend
- [ ] Infra/CI
- [ ] Docs

## ✨ Changes
- 
- 

## 🧪 How to Test
### Backend
- [ ] 포스트맨 API 응답 확인
- [ ] docker compose 실행

### Frontend
- [ ] 로컬 실행
- [ ] 주요 화면/기능 확인

## 🔗 Related Issue
Closes #68

## ✅ Checklist
- [ ] CI 통과
- [ ] 불필요한 로그/주석 제거
- [ ] ENV/설정 변경 시 `.env.example` / README 업데이트 !!!
- [ ] (필요 시) 마이그레이션/스키마 변경 내용 공유
